### PR TITLE
Add resource attrs to console export

### DIFF
--- a/lib/opentelemetry/trace/exporter/encoder.lua
+++ b/lib/opentelemetry/trace/exporter/encoder.lua
@@ -77,7 +77,9 @@ end
 --------------------------------------------------------------------------------
 function _M.for_console(span)
     local ret = "\n---------------------------------------------------------\n"
-    ret = ret .. util.table_as_string(_M.for_export(span), 2)
+    local ex = _M.for_export(span)
+    ex["resource_attributes"] = span.tracer.provider.resource.attrs
+    ret = ret .. util.table_as_string(ex, 2)
     ret = ret .. "---------------------------------------------------------\n"
     return ret
 end


### PR DESCRIPTION
An example exporting with this code
```
2024/03/13 15:50:54 [info] 4#4: *103 [lua] console.lua:32: export_spans(): Export spans:
---------------------------------------------------------
  resource_attributes = {
    1 = {
      key = "telemetry.sdk.language"
      value = {
        string_value = "lua"
      }
    }
    2 = {
      key = "telemetry.sdk.name"
      value = {
        string_value = "opentelemetry-lua"
      }
    }
    3 = {
      key = "telemetry.sdk.version"
      value = {
        string_value = "0.1.1"
      }
    }
    4 = {
      key = "host.name"
      value = {
        string_value = "db664ee9bb41"
      }
    }
    ...
 ```